### PR TITLE
Github Actionsのトリガーを変更/転送内容に時間情報を付与しないように変更

### DIFF
--- a/.github/workflows/share_start.yml
+++ b/.github/workflows/share_start.yml
@@ -1,11 +1,14 @@
 name : データ転送実行
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
-      - master
+      - transfer/**
 
 jobs:
-  build:
+  if_merged:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     env:

--- a/.github/workflows/share_start.yml
+++ b/.github/workflows/share_start.yml
@@ -4,11 +4,12 @@ on:
     types:
       - closed
     branches:
-      - transfer/**
+      - master
 
 jobs:
   if_merged:
     if: github.event.pull_request.merged == true
+    if: startsWith(github.head_ref, 'transfer/')
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     env:


### PR DESCRIPTION
# 対応内容
- S3のポリシーを変更し、現在時刻を対象バケットへ付与しなくても上書きで転送できるように変更 https://github.com/nijigen-plot/between-s3-data-share/commit/7c31136b99f2ba4d59c1402097eecbfb0a58761c
- `transfer/**`に該当するブランチ名から`master`に対してのプルリクをマージしたときに転送が開始されるよう修正
  - https://github.com/nijigen-plot/between-s3-data-share/commit/282cbc74b40bf9e361bcc9643a6816cd837a6552
  - https://github.com/nijigen-plot/between-s3-data-share/commit/f6c00733a2ffeab35bed9429263c62c116d31920