### PR TITLE
必要が無い為s3_outputの記載を削除

### DIFF
--- a/arguments.json
+++ b/arguments.json
@@ -3,6 +3,5 @@
     "unload_to_s3_uri": "s3://quark-sandbox/unload-data/practice-sales/",
     "share_exclusive_s3_uri": "s3://data-share-only-bucket/practice-sales/",
     "transfer_target_s3_uri": "s3://s3-share-data-receive/practice-sales-2/",
-    "workgroup": "primary",
-    "s3_output": "s3://query-results-bucker/primary_folder/"
+    "workgroup": "primary"
 }

--- a/main.py
+++ b/main.py
@@ -24,7 +24,6 @@ def main():
     share_exclusive_s3_uri = params["share_exclusive_s3_uri"]
     transfer_target_s3_uri = params["transfer_target_s3_uri"]
     workgroup = params["workgroup"]
-    s3_output = params["s3_output"]
     unload_query = f"""
     UNLOAD( {unload_select_query} )
     TO '{unload_to_s3_uri}'
@@ -37,9 +36,7 @@ def main():
     delete_objects(transfer_target_s3_uri, session)
 
     # UNLOAD実行 unload_resultからはQueryExecutionIdを取得する
-    wr.athena.start_query_execution(
-        unload_query, s3_output=s3_output, boto3_session=session, workgroup=workgroup, wait=True
-    )
+    wr.athena.start_query_execution(unload_query, boto3_session=session, workgroup=workgroup, wait=True)
 
     # 共有バケットへのコピーを実行
     unload_objects = wr.s3.list_objects(path=unload_to_s3_uri, boto3_session=session)


### PR DESCRIPTION
UNLOADにはクエリ実行結果を保存する必要が無いためs3_outputの項目を削除