### PR TITLE
データ転送構造を変更

### DIFF
--- a/CloudFormation/share_env_setup.yml
+++ b/CloudFormation/share_env_setup.yml
@@ -1,23 +1,15 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Setup for data transfer between S3 bucket accounts
 
-Parameters:
-  S3BucketName:
-    Type: String
-    Default: data-share-only
-  UserName:
-    Type: String
-    Default: S3-data-transfer
-
 Resources:
   CreateUser:
     Type: AWS::IAM::User
     Properties:
-      UserName: !Sub ${UserName}
+      UserName: S3-data-transfer
   CreateShareS3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub ${S3BucketName}
+      BucketName: data-share-only
   CreateAthenaUnloadPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -44,8 +36,8 @@ Resources:
               - "arn:aws:s3:::query-results-bucker"
               - "arn:aws:s3:::quark-sandbox/*"
               - "arn:aws:s3:::quark-sandbox"
-              - !Sub "arn:aws:s3:::${S3BucketName}/*"
-              - !Sub "arn:aws:s3:::${S3BucketName}"
+              - "arn:aws:s3:::data-share-only/*"
+              - "arn:aws:s3:::data-share-only"
           - Sid: "AthenaAccess"
             Effect: "Allow"
             Action: 
@@ -104,7 +96,6 @@ Resources:
             Action: 
               - "s3:ListBucket"
               - "s3:PutObject"
-              - "s3:DeleteObject"
             Resource: 
               - "arn:aws:s3:::s3-share-data-receive/*"
               - "arn:aws:s3:::s3-share-data-receive"
@@ -126,10 +117,10 @@ Resources:
               - "s3:ListBucketMultipartUploads"
               - "s3:GetBucketLocation"
             Resource: 
-              - !Sub "arn:aws:s3:::${S3BucketName}/*"
-              - !Sub "arn:aws:s3:::${S3BucketName}"
+              - "arn:aws:s3:::data-share-only/*"
+              - "arn:aws:s3:::data-share-only"
             Condition: 
               ArnNotEquals: 
                 aws:PrincipalArn: 
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:user/${UserName}"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:user/S3-data-transfer"
       Bucket: !Ref CreateShareS3Bucket

--- a/arguments.json
+++ b/arguments.json
@@ -1,7 +1,6 @@
 {
     "unload_select_query_file_directory": "./unload_select_query.sql",
-    "unload_to_s3_uri": "s3://quark-sandbox/unload-data/practice-sales/",
-    "share_exclusive_s3_uri": "s3://data-share-only/practice-sales/",
-    "transfer_target_s3_uri": "s3://s3-share-data-receive/practice-sales-2/",
+    "share_exclusive_s3_uri": "s3://data-share-only/practice-sales-4/",
+    "transfer_target_s3_uri": "s3://s3-share-data-receive/practice-sales-4/",
     "workgroup": "primary"
 }

--- a/main.py
+++ b/main.py
@@ -25,28 +25,20 @@ def main():
     params = json.load(open("./arguments.json"))
     unload_select_query_file_directory = params["unload_select_query_file_directory"]
     unload_select_query = open(unload_select_query_file_directory, "r").read()
-    unload_to_s3_uri = params["unload_to_s3_uri"]
     share_exclusive_s3_uri = params["share_exclusive_s3_uri"]
     transfer_target_s3_uri = params["transfer_target_s3_uri"]
     workgroup = params["workgroup"]
     unload_query = f"""
     UNLOAD( {unload_select_query} )
-    TO '{unload_to_s3_uri}'
+    TO '{share_exclusive_s3_uri}'
     WITH ( format = 'PARQUET')
     """
 
-    # 共有と転送先について既にオブジェクトがある場合は実行を終了する
-    object_length_check(share_exclusive_s3_uri, session)
+    # 転送先について既にオブジェクトがある場合は実行を終了する
     object_length_check(transfer_target_s3_uri, session)
 
-    # UNLOAD実行 TOのフォルダ内に既にオブジェクトが存在する場合、実行は失敗する
+    # UNLOAD実行 共有フォルダ内に既にオブジェクトが存在する場合、実行は失敗する
     wr.athena.start_query_execution(unload_query, boto3_session=session, workgroup=workgroup, wait=True)
-
-    # 共有バケットへのコピーを実行 なんらかのエラーが発生した場合はUNLOADにより保存されたオブジェクトを削除する必要が有る
-    unload_objects = wr.s3.list_objects(path=unload_to_s3_uri, boto3_session=session)
-    wr.s3.copy_objects(
-        paths=unload_objects, source_path=unload_to_s3_uri, target_path=share_exclusive_s3_uri, boto3_session=session
-    )
 
     # 異なるアカウントのS3バケットへのコピーを実行 権限周りで失敗した場合は共有バケットへコピーしたデータを削除する
     share_objects = wr.s3.list_objects(path=share_exclusive_s3_uri, boto3_session=session)

--- a/receive_bucket_policy.json
+++ b/receive_bucket_policy.json
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Id": "Policy1611277539797",
+    "Statement": [
+        {
+            "Sid": "Stmt1611277535086",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::xxxxxxxxx:user/S3-data-transfer"
+                ]
+            },
+            "Action": [
+                "s3:ListBucket",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::s3-share-data-receive/*",
+                "arn:aws:s3:::s3-share-data-receive"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# 対応内容
- データ転送時、UNLOAD先を直接共有バケットへするように変更
  - 一度UNLOAD先データを共有バケットへコピーする工程が無くなった
- CloudFormationのParameterを削除し、直接記載
  - 違うパターンで毎回実行するようなことが想定されないため
- 受け手側バケットポリシーの例を追加